### PR TITLE
refactored to minimize synchronization for improved multi-threaded pe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/
 .settings
 /GeoIP/
 geoip-test-databases.tar.gz
+/bin/


### PR DESCRIPTION
…rformance

Because of the structural changes in `LookupService`, it may just be easier to read the old and new code side by side rather than trying to follow a diff.  All of the changes are structural, I did not change any of the logic related to reading or decoding data.

The old code had a lot of synchronization in top-level methods, and indeed in various internal methods as well.  These were blanket synchronizations that protected various mutable state of the service.

To minimize synchronization I isolated the state which really needs synchronization protection -- (1) state related to reloading or closing the database (only needed if the database is reloadable and/or closeable); (2) the file handle for reading data from disk; (3) the charset decoder.  

I had to push the database-related fields down into a new, internal `Database` class to support reloading of a database without always synchronizing.  In the normal case we only need a volatile read to get the database instance (and even this can be avoided if the database is not reloadable/closeable).  Within this `Database` instance, synchronization is only needed when using the file handle to read data from disk (and this is not needed if the service is being used in memory-cached mode).